### PR TITLE
Upgrading to newer inspect-function-declarations package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "inspect-function",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -300,40 +300,20 @@
       }
     },
     "inspect-parameters-declaration": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.8.tgz",
-      "integrity": "sha512-W4QzN1LgFmasKOM+NoLlDd2OAZM3enNZlVUOXoGQKmYBDFgxoPDOyebF55ALaf8avyM9TavNwibXxg347RrzCg==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.1.0.tgz",
+      "integrity": "sha512-06xVJBwmGsVwA/Nap6Yfb2PFP+qJWibVzGRvYtA9DiEJqhZNlSB2uEoDGBlGinSiOOGGldozT5fMZD0ZhVJB1w==",
       "requires": {
-        "magicli": "0.0.5",
+        "magicli": "0.0.8",
         "split-skip": "0.0.2",
-        "stringify-parameters": "0.0.4",
+        "stringify-parameters": "0.0.7",
         "unpack-string": "0.0.2"
       },
       "dependencies": {
-        "magicli": {
-          "version": "0.0.5",
-          "resolved": "https://registry.npmjs.org/magicli/-/magicli-0.0.5.tgz",
-          "integrity": "sha1-zufQ+7THBRiqyxHsPrfiX/SaSSE=",
-          "requires": {
-            "commander": "^2.9.0",
-            "get-stdin": "^5.0.1",
-            "inspect-function": "^0.2.1",
-            "pipe-functions": "^1.2.0"
-          }
-        },
         "split-skip": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
           "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
-        },
-        "stringify-parameters": {
-          "version": "0.0.4",
-          "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",
-          "integrity": "sha512-H3L90ERn5UPtkpO8eugnKcLgpIVlvTyUTrcLGm607AV5JDH6z0GymtNLr3gjGlP6I6NB/mxNX9QpY6jEQGLPdQ==",
-          "requires": {
-            "magicli": "0.0.5",
-            "unpack-string": "0.0.2"
-          }
         }
       }
     },
@@ -358,6 +338,24 @@
             "unpack-string": "0.0.2"
           },
           "dependencies": {
+            "inspect-parameters-declaration": {
+              "version": "0.0.8",
+              "resolved": "https://registry.npmjs.org/inspect-parameters-declaration/-/inspect-parameters-declaration-0.0.8.tgz",
+              "integrity": "sha512-W4QzN1LgFmasKOM+NoLlDd2OAZM3enNZlVUOXoGQKmYBDFgxoPDOyebF55ALaf8avyM9TavNwibXxg347RrzCg==",
+              "requires": {
+                "magicli": "0.0.5",
+                "split-skip": "0.0.2",
+                "stringify-parameters": "0.0.4",
+                "unpack-string": "0.0.2"
+              },
+              "dependencies": {
+                "split-skip": {
+                  "version": "0.0.2",
+                  "resolved": "https://registry.npmjs.org/split-skip/-/split-skip-0.0.2.tgz",
+                  "integrity": "sha1-2J2Iu9L3Pka1FYqjcKVhIk6A1GE="
+                }
+              }
+            },
             "stringify-parameters": {
               "version": "0.0.4",
               "resolved": "https://registry.npmjs.org/stringify-parameters/-/stringify-parameters-0.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "mocha": "^5.2.0"
   },
   "dependencies": {
-    "inspect-parameters-declaration": "0.0.8",
+    "inspect-parameters-declaration": "0.1.0",
     "magicli": "0.0.8",
     "split-skip": "0.0.1",
     "stringify-parameters": "0.0.7",


### PR DESCRIPTION
Right now, rest parameters are not being parsed properly. Simple example:
```javascript
const inspect = require('inspect-function');
const Test = { a: (b=[], c={}, ...d) => { console.log({ b, c, d }); } }
inspect(Test.a);
```

returns:
```
{
  fn: [Function: a],
  name: 'a',
  signature: 'a(b=[], c={}, ...d);',
  parameters: [
    { parameter: 'b', defaultValue: '[]', declaration: 'b=[]' },
    { parameter: 'c', defaultValue: '{}', declaration: 'c={}' },
    { parameter: '...d', declaration: '...d' }
  ],
  parametersNames: [ 'b', 'c', '...d' ]
}
```

Upgrading to the latest inspect-function-declarations package fixes that.